### PR TITLE
Asserting for component addresses and package addresses of components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT"
 description = "Common datatypes which are used in the Ociswap core pools"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod math;
+pub mod metadata;
 pub mod pools;
 pub mod time;
 pub mod utils;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,48 @@
+use scrypto::prelude::*;
+
+pub fn assert_component_packages_are_approved(
+    metadata_key: &str,
+    component_addresses: Vec<ComponentAddress>,
+) {
+    let metadata_package_addresses = addresses_from_metadata(&metadata_key);
+
+    for component_address in component_addresses {
+        let blueprint_id = ScryptoVmV1Api::object_get_blueprint_id(&component_address.into());
+        assert!(
+            metadata_package_addresses.contains(&blueprint_id.package_address),
+            "The package address of {} is not approved under the key {} in the pool package metadata.",
+            Runtime::bech32_encode_address(component_address),
+            metadata_key
+        );
+    }
+}
+
+pub fn assert_components_are_approved(
+    metadata_key: &str,
+    component_addresses: Vec<ComponentAddress>,
+) {
+    let metadata_component_addresses = addresses_from_metadata(&metadata_key);
+
+    for component_address in component_addresses {
+        assert!(
+            metadata_component_addresses.contains(&component_address),
+            "{} is not approved under the key {} in the pool package metadata.",
+            Runtime::bech32_encode_address(component_address),
+            metadata_key
+        );
+    }
+}
+
+pub fn addresses_from_metadata<T>(key: &str) -> Vec<T>
+where
+    T: TryFrom<GlobalAddress>,
+{
+    let own_package: Package = Runtime::package_address().into();
+    let metadata_value: Option<Vec<GlobalAddress>> = own_package.get_metadata(key).ok().flatten();
+
+    metadata_value
+        .into_iter()
+        .flatten()
+        .filter_map(|address| address.try_into().ok())
+        .collect()
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,30 +26,3 @@ pub fn sort_buckets(a_bucket: Bucket, b_bucket: Bucket) -> (Bucket, Bucket) {
     }
     (b_bucket, a_bucket)
 }
-
-pub fn assert_components_are_approved(
-    metadata_key: &str,
-    component_addresses: Vec<ComponentAddress>,
-) {
-    let metadata_package_addresses = package_addresses_from_metadata(&metadata_key);
-
-    for component_address in component_addresses {
-        let blueprint_id = ScryptoVmV1Api::object_get_blueprint_id(&component_address.into());
-        assert!(
-            metadata_package_addresses.contains(&blueprint_id.package_address),
-            "The package address of {} is not approved under the key {} in the pool package metadata.",
-            Runtime::bech32_encode_address(component_address),
-            metadata_key
-        );
-    }
-}
-
-pub fn package_addresses_from_metadata(key: &str) -> Vec<PackageAddress> {
-    let own_package: Package = Runtime::package_address().into();
-    let metadata_value: Option<Vec<GlobalAddress>> = own_package.get_metadata(key).ok().flatten();
-    metadata_value
-        .into_iter()
-        .flatten()
-        .filter_map(|address| address.try_into().ok())
-        .collect()
-}


### PR DESCRIPTION
Support asserting for component addresses and package addresses of components from the package metadata. This allows for granular control and gives both options for different use cases.